### PR TITLE
Corrected lsi file now matching expected outputs

### DIFF
--- a/PI3/Exercise 2/Model.lsi
+++ b/PI3/Exercise 2/Model.lsi
@@ -20,7 +20,7 @@ constraints section
 
 sum(selected[course], course in 0 .. courses | getArea(course) = area) - 1 >= 0, area in 0 .. areas
 
-sum(selected[course], course in 0 .. courses | getArea(course) = 0) - sum(selected[course], course in 0 .. courses | getArea(course) != 0) >= 0
+sum(selected[course], course in 0 .. courses | getArea(course) = 0) - sum(selected[course], course in 0 .. courses | getArea(course) = a) >= 0, a in 1 .. areas
 
 sum(getDuracion(course) selected[course], course in 0 .. courses) - sum(20 selected[course], course in 0 .. courses) >= 0
 


### PR DESCRIPTION
Now your Exercise2PLE matches the expected outputs for all data entries, that is, 18-21-28.